### PR TITLE
feat(on-canvas-click): clique sur la carte pour obtenir les coordonnées correspondantes au point cliqué

### DIFF
--- a/myfirstplugin_dialog_base.ui
+++ b/myfirstplugin_dialog_base.ui
@@ -10,7 +10,7 @@
     <x>0</x>
     <y>0</y>
     <width>536</width>
-    <height>441</height>
+    <height>594</height>
    </rect>
   </property>
   <property name="palette">
@@ -462,7 +462,7 @@
    <property name="geometry">
     <rect>
      <x>180</x>
-     <y>400</y>
+     <y>550</y>
      <width>341</width>
      <height>32</height>
     </rect>
@@ -925,6 +925,11 @@
      </disabled>
     </palette>
    </property>
+   <property name="font">
+    <font>
+     <pointsize>12</pointsize>
+    </font>
+   </property>
    <property name="text">
     <string>Liste des couches :</string>
    </property>
@@ -972,6 +977,78 @@ color: rgb(0, 0, 0);</string>
    </property>
    <property name="scaledContents">
     <bool>true</bool>
+   </property>
+  </widget>
+  <widget class="QLabel" name="clicked_point">
+   <property name="geometry">
+    <rect>
+     <x>30</x>
+     <y>310</y>
+     <width>211</width>
+     <height>16</height>
+    </rect>
+   </property>
+   <property name="font">
+    <font>
+     <pointsize>12</pointsize>
+    </font>
+   </property>
+   <property name="text">
+    <string>Point cliqué :</string>
+   </property>
+  </widget>
+  <widget class="QLineEdit" name="longitude_point">
+   <property name="geometry">
+    <rect>
+     <x>110</x>
+     <y>350</y>
+     <width>141</width>
+     <height>23</height>
+    </rect>
+   </property>
+   <property name="styleSheet">
+    <string notr="true">background-color: rgb(226, 220, 193);
+color: rgb(0, 0, 0);</string>
+   </property>
+  </widget>
+  <widget class="QLabel" name="longitude_label">
+   <property name="geometry">
+    <rect>
+     <x>40</x>
+     <y>350</y>
+     <width>61</width>
+     <height>21</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>Longitude</string>
+   </property>
+  </widget>
+  <widget class="QLineEdit" name="latitude_point">
+   <property name="geometry">
+    <rect>
+     <x>350</x>
+     <y>350</y>
+     <width>141</width>
+     <height>23</height>
+    </rect>
+   </property>
+   <property name="styleSheet">
+    <string notr="true">background-color: rgb(226, 220, 193);
+color: rgb(0, 0, 0);</string>
+   </property>
+  </widget>
+  <widget class="QLabel" name="latitude_label">
+   <property name="geometry">
+    <rect>
+     <x>290</x>
+     <y>350</y>
+     <width>61</width>
+     <height>21</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>Latitude</string>
    </property>
   </widget>
  </widget>


### PR DESCRIPTION
En tant qu’utilisateur de l’extension,
Je souhaite pouvoir cliquer sur la carte et obtenir les coordonnées correspondantes au point cliqué
Règles
RG1 : Les coordonnées affichées doivent correspondre au SCR “WGS 84” (EPSG:4326)
RG2 : Les coordonnées affichées doivent être arrondies (cinq décimales après la virgule)