### PR TITLE
feat(reverse-geocoding): clique sur la carte et obtiens l'adresse de la BAN la plus proche du point cliqué

### DIFF
--- a/myfirstplugin_dialog_base.ui
+++ b/myfirstplugin_dialog_base.ui
@@ -1051,6 +1051,38 @@ color: rgb(0, 0, 0);</string>
     <string>Latitude</string>
    </property>
   </widget>
+  <widget class="QLabel" name="address_label">
+   <property name="geometry">
+    <rect>
+     <x>30</x>
+     <y>410</y>
+     <width>81</width>
+     <height>21</height>
+    </rect>
+   </property>
+   <property name="font">
+    <font>
+     <pointsize>12</pointsize>
+    </font>
+   </property>
+   <property name="text">
+    <string>Adresse :</string>
+   </property>
+  </widget>
+  <widget class="QLineEdit" name="address_edit">
+   <property name="geometry">
+    <rect>
+     <x>120</x>
+     <y>410</y>
+     <width>381</width>
+     <height>23</height>
+    </rect>
+   </property>
+   <property name="styleSheet">
+    <string notr="true">background-color: rgb(226, 220, 193);
+color: rgb(0, 0, 0);</string>
+   </property>
+  </widget>
  </widget>
  <resources/>
  <connections>


### PR DESCRIPTION
En tant qu’utilisateur de l’extension,
Je souhaite pouvoir cliquer sur la carte et obtenir l’adresse BAN la plus proche du point cliqué
Règles
RG1 : Ne rechercher que l’adresse postale la plus proche
RG2 : Pour l’adresse postale la plus proche, afficher :
- le numéro dans la voie
- le type et le nom de la voie
- le code INSEE de la commune (et pas le code postal…)
- le nom de la commune
