### PR TITLE
feat(tampon): jointure spatiale entre le tampon et ma couche et compte le nombre de feature + implémentation de la valeur dans le widget

### DIFF
--- a/myfirstplugin.py
+++ b/myfirstplugin.py
@@ -25,9 +25,12 @@ from qgis.PyQt.QtCore import QSettings, QTranslator, QCoreApplication
 from qgis.PyQt.QtGui import QIcon
 from qgis.PyQt.QtWidgets import QAction
 
-from qgis.core import QgsProject, QgsVectorLayer, QgsPointXY, QgsCoordinateReferenceSystem, QgsCoordinateTransform, QgsGeometry, QgsFeatureRequest
-from qgis.gui import QgsMapToolEmitPoint
+from PyQt5.QtWidgets import QMessageBox
+from PyQt5.QtCore import QVariant
 
+from qgis.core import QgsProject, QgsVectorLayer, QgsPointXY, QgsCoordinateReferenceSystem, QgsCoordinateTransform, QgsGeometry, QgsFeatureRequest, QgsFeature, QgsField
+from qgis.gui import QgsMapToolEmitPoint
+from qgis.PyQt.QtGui import QColor
 import requests
 
 from .resources import *
@@ -129,11 +132,16 @@ class PluginScript:
         if result:
             pass
 
+    
+    # fonction utilitaire de transformation de systeme de projection
+    def transform_coordinates(self, point, source_crs, target_crs):
+        transform = QgsCoordinateTransform(source_crs, target_crs, QgsProject.instance())
+        return transform.transform(point)
 
-    # liste les couches ponctuels dans le projet courant 
+    # liste les couches ponctuels dans le projet courant
     def list_layers(self):
 
-        # clear le contenue de mon widget comboxbox avant chaque lancement de la fonction 
+        # clear le contenue de mon widget comboxbox avant chaque lancement de la fonction
         self.dlg.combobox_layers.clear()
 
         # récupère les noms des couches du projet courant
@@ -143,53 +151,57 @@ class PluginScript:
             # filtre uniquement les couches vectorielles
             if layer.type() == QgsVectorLayer.VectorLayer:
 
-                # filtre uniquement les couches poncutelles 
+                # filtre uniquement les couches poncutelles
                 if layer.wkbType() == 1:
-                    print(layer.name())
                     self.dlg.combobox_layers.addItem(layer.name())
 
     # clique sur la carte pour obtenir les coordonnées correspondantes au point cliqué
     def on_canvas_click(self, point):
-
-        # retourne les coordonnées à partir de la projection du canvas
+        # récupère les coordonnées du point cliqué dans le système de coordonnées du canvas
         map_point = QgsPointXY(point.x(), point.y())
 
-        # système de projection de destination (EPSG:4326)
-        wgs_crs = QgsCoordinateReferenceSystem("EPSG:4326")
-
-        # projection (EPSG:3857) actuelle du canvas
+        # transforme des coordonnées (EPSG:4326)
         map_crs = self.canvas.mapSettings().destinationCrs()
+        wgs_crs = QgsCoordinateReferenceSystem("EPSG:4326")
+        point_wgs = self.transform_coordinates(map_point, map_crs, wgs_crs)
 
-        # converti les coordonnées 3857 en 4326
-        transform = QgsCoordinateTransform(map_crs, wgs_crs, QgsProject.instance())
-        point_wgs = transform.transform(map_point)
+        # recup la distance du buffer depuis l'interface utilisateur
+        distance_meters = self.dlg.meters_label.text()
 
+        if not distance_meters.isdigit():
+            QMessageBox.warning(self.dlg, "Erreur", "Veuillez entrer une distance valide en mètres.")
+            return
+
+        # creation du point et du tampon
         point_geometry = QgsGeometry.fromPointXY(map_point)
-        buffer_geometry = point_geometry.buffer(10, 5)
+        buffer_geometry = point_geometry.buffer(float(distance_meters), 5)
 
-        # extraction du long et lat
+        # extract du long et lat
         lon = round(point_wgs.x(), 5)
         lat = round(point_wgs.y(), 5)
-        
         print(f'lon : {lon}, lat : {lat}')
 
-        # affiche mes lon et lat dans mon qlineedit
+        # affiche les coordonnées dans l'interface utilisateur
         self.dlg.longitude_point.setText(str(lon))
         self.dlg.latitude_point.setText(str(lat))
 
+        # effecue le géocodage inverse
         self.reverse_geocoding(lon, lat)
 
+        # recup le nom de la couche sélectionnée
         select_layername = self.dlg.combobox_layers.currentText()
 
-        if select_layername :
+        if select_layername:
             self.count_objects_nearest(select_layername, buffer_geometry)
+
+
 
     # clique sur la carte et obtiens l’adresse BAN la plus proche du point cliqué
     def reverse_geocoding(self, lon, lat):
         url = f'https://data.geopf.fr/geocodage/reverse?lat={lat}&lon={lon}&limit=1&type=housenumber'
 
         try:
-            
+
             # requetage sur l'api ban en type get
             response = requests.get(url)
 
@@ -208,16 +220,19 @@ class PluginScript:
 
                     address = f'{name_voie}, {citycode} {city}'
 
+                    # ajout la valeur au widget
                     self.dlg.address_edit.setText(str(address))
-                
+
                 else :
                     self.dlg.address_edit.setText(f'Adresse introuvable')
 
         except Exception as e:
             self.dlg.address_edit.setText(f'Erreur : {e}')
 
+    # compte les objets dans le buffer
     def count_objects_nearest(self, layer_name, buffer_geom):
 
+        # récupère la couche du combobox
         layer = QgsProject.instance().mapLayersByName(layer_name)[0]
 
         if not layer:
@@ -228,14 +243,17 @@ class PluginScript:
 
         map_crs = self.canvas.mapSettings().destinationCrs()
 
+        # transforme la géométrie du buffer dans le CRS de la couche
         transform = QgsCoordinateTransform(map_crs, layer_crs, QgsProject.instance())
-
         buffer_geom.transform(transform)
 
+        # compte le nb de feature à partir d'une jointure spatiale 
         count = 0
         for feature in layer.getFeatures():
             feature_geom = feature.geometry()
             if feature_geom.intersects(buffer_geom):
                 count += 1
+
+        self.dlg.object_label.setText(str(count))
 
         print(f"Nombre d'entités intersectées dans le buffer : {count}")

--- a/myfirstplugin_dialog_base.ui
+++ b/myfirstplugin_dialog_base.ui
@@ -1010,6 +1010,15 @@ color: rgb(0, 0, 0);</string>
     <string notr="true">background-color: rgb(226, 220, 193);
 color: rgb(0, 0, 0);</string>
    </property>
+   <property name="dragEnabled">
+    <bool>true</bool>
+   </property>
+   <property name="readOnly">
+    <bool>true</bool>
+   </property>
+   <property name="clearButtonEnabled">
+    <bool>true</bool>
+   </property>
   </widget>
   <widget class="QLabel" name="longitude_label">
    <property name="geometry">
@@ -1036,6 +1045,15 @@ color: rgb(0, 0, 0);</string>
    <property name="styleSheet">
     <string notr="true">background-color: rgb(226, 220, 193);
 color: rgb(0, 0, 0);</string>
+   </property>
+   <property name="dragEnabled">
+    <bool>true</bool>
+   </property>
+   <property name="readOnly">
+    <bool>true</bool>
+   </property>
+   <property name="clearButtonEnabled">
+    <bool>true</bool>
    </property>
   </widget>
   <widget class="QLabel" name="latitude_label">
@@ -1082,6 +1100,15 @@ color: rgb(0, 0, 0);</string>
     <string notr="true">background-color: rgb(226, 220, 193);
 color: rgb(0, 0, 0);</string>
    </property>
+   <property name="dragEnabled">
+    <bool>true</bool>
+   </property>
+   <property name="readOnly">
+    <bool>true</bool>
+   </property>
+   <property name="clearButtonEnabled">
+    <bool>true</bool>
+   </property>
   </widget>
   <widget class="QLabel" name="address_label_2">
    <property name="geometry">
@@ -1101,7 +1128,7 @@ color: rgb(0, 0, 0);</string>
     <string>Nombres d'objets :</string>
    </property>
   </widget>
-  <widget class="QLabel" name="longitude_label_2">
+  <widget class="QLabel" name="text">
    <property name="geometry">
     <rect>
      <x>40</x>
@@ -1114,7 +1141,7 @@ color: rgb(0, 0, 0);</string>
     <string>Il y a</string>
    </property>
   </widget>
-  <widget class="QLabel" name="longitude_label_3">
+  <widget class="QLabel" name="text_2">
    <property name="geometry">
     <rect>
      <x>140</x>
@@ -1127,7 +1154,7 @@ color: rgb(0, 0, 0);</string>
     <string>objet(s) à moins de </string>
    </property>
   </widget>
-  <widget class="QLabel" name="longitude_label_4">
+  <widget class="QLabel" name="text_3">
    <property name="geometry">
     <rect>
      <x>330</x>

--- a/myfirstplugin_dialog_base.ui
+++ b/myfirstplugin_dialog_base.ui
@@ -983,7 +983,7 @@ color: rgb(0, 0, 0);</string>
    <property name="geometry">
     <rect>
      <x>30</x>
-     <y>310</y>
+     <y>300</y>
      <width>211</width>
      <height>16</height>
     </rect>
@@ -1000,8 +1000,8 @@ color: rgb(0, 0, 0);</string>
   <widget class="QLineEdit" name="longitude_point">
    <property name="geometry">
     <rect>
-     <x>110</x>
-     <y>350</y>
+     <x>120</x>
+     <y>340</y>
      <width>141</width>
      <height>23</height>
     </rect>
@@ -1014,8 +1014,8 @@ color: rgb(0, 0, 0);</string>
   <widget class="QLabel" name="longitude_label">
    <property name="geometry">
     <rect>
-     <x>40</x>
-     <y>350</y>
+     <x>50</x>
+     <y>340</y>
      <width>61</width>
      <height>21</height>
     </rect>
@@ -1028,7 +1028,7 @@ color: rgb(0, 0, 0);</string>
    <property name="geometry">
     <rect>
      <x>350</x>
-     <y>350</y>
+     <y>340</y>
      <width>141</width>
      <height>23</height>
     </rect>
@@ -1042,7 +1042,7 @@ color: rgb(0, 0, 0);</string>
    <property name="geometry">
     <rect>
      <x>290</x>
-     <y>350</y>
+     <y>340</y>
      <width>61</width>
      <height>21</height>
     </rect>
@@ -1055,7 +1055,7 @@ color: rgb(0, 0, 0);</string>
    <property name="geometry">
     <rect>
      <x>30</x>
-     <y>410</y>
+     <y>400</y>
      <width>81</width>
      <height>21</height>
     </rect>
@@ -1073,7 +1073,7 @@ color: rgb(0, 0, 0);</string>
    <property name="geometry">
     <rect>
      <x>120</x>
-     <y>410</y>
+     <y>400</y>
      <width>381</width>
      <height>23</height>
     </rect>
@@ -1081,6 +1081,96 @@ color: rgb(0, 0, 0);</string>
    <property name="styleSheet">
     <string notr="true">background-color: rgb(226, 220, 193);
 color: rgb(0, 0, 0);</string>
+   </property>
+  </widget>
+  <widget class="QLabel" name="address_label_2">
+   <property name="geometry">
+    <rect>
+     <x>30</x>
+     <y>460</y>
+     <width>151</width>
+     <height>21</height>
+    </rect>
+   </property>
+   <property name="font">
+    <font>
+     <pointsize>12</pointsize>
+    </font>
+   </property>
+   <property name="text">
+    <string>Nombres d'objets :</string>
+   </property>
+  </widget>
+  <widget class="QLabel" name="longitude_label_2">
+   <property name="geometry">
+    <rect>
+     <x>40</x>
+     <y>510</y>
+     <width>31</width>
+     <height>21</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>Il y a</string>
+   </property>
+  </widget>
+  <widget class="QLabel" name="longitude_label_3">
+   <property name="geometry">
+    <rect>
+     <x>140</x>
+     <y>510</y>
+     <width>121</width>
+     <height>21</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>objet(s) à moins de </string>
+   </property>
+  </widget>
+  <widget class="QLabel" name="longitude_label_4">
+   <property name="geometry">
+    <rect>
+     <x>330</x>
+     <y>510</y>
+     <width>141</width>
+     <height>21</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>mètres du point cliqué</string>
+   </property>
+  </widget>
+  <widget class="QLineEdit" name="meters_label">
+   <property name="geometry">
+    <rect>
+     <x>270</x>
+     <y>510</y>
+     <width>51</width>
+     <height>23</height>
+    </rect>
+   </property>
+   <property name="styleSheet">
+    <string notr="true">background-color: rgb(226, 220, 193);
+color: rgb(0, 0, 0);</string>
+   </property>
+  </widget>
+  <widget class="QLabel" name="object_label">
+   <property name="geometry">
+    <rect>
+     <x>80</x>
+     <y>510</y>
+     <width>51</width>
+     <height>21</height>
+    </rect>
+   </property>
+   <property name="layoutDirection">
+    <enum>Qt::LeftToRight</enum>
+   </property>
+   <property name="text">
+    <string/>
+   </property>
+   <property name="alignment">
+    <set>Qt::AlignCenter</set>
    </property>
   </widget>
  </widget>


### PR DESCRIPTION
En tant qu’utilisateur de l’extension,
Je souhaite pouvoir cliquer sur la carte et connaître le nombre d’objets situés à X mètres du point cliqué
Règles
RG1 : Un champ doit me permettre de saisir une distance en mètres (X)
RG2 : Si la distance renseignée n’est pas un nombre entier, afficher un message d’erreur dans QGIS
RG3 : Les objets à compter sont ceux appartenant à la couche sélectionnée dans la liste déroulante
→ Voir la fonctionnalité réalisée dans le cadre de l’User Story n°1